### PR TITLE
Removing hard-coded CONLL File header

### DIFF
--- a/wildnlp/datasets/conll.py
+++ b/wildnlp/datasets/conll.py
@@ -8,7 +8,9 @@ class CoNLL(Dataset):
     entity recognition. For details see:
     https://www.clips.uantwerpen.be/conll2003/ner/
     """
-    datasetFileHeader: str
+    def __init__(self):
+        self._dataset_file_header: str = ''
+        super().__init__()
 
     @file_exists_check
     def load(self, path):
@@ -34,7 +36,7 @@ class CoNLL(Dataset):
         with open(path, "r") as f:
             for line in f.readlines():
                 if str(line).startswith('-DOCSTART-'):
-                    self.datasetFileHeader = str(line)
+                    self._dataset_file_header = str(line)
                     continue
 
                 elif line == "\n":
@@ -123,7 +125,7 @@ class CoNLL(Dataset):
         with open(path, 'w+') as f:
 
             lines = list()
-            lines.append(self.datasetFileHeader)
+            lines.append(self._dataset_file_header)
 
             try:
                 for entry in data:

--- a/wildnlp/datasets/conll.py
+++ b/wildnlp/datasets/conll.py
@@ -8,6 +8,7 @@ class CoNLL(Dataset):
     entity recognition. For details see:
     https://www.clips.uantwerpen.be/conll2003/ner/
     """
+    datasetFileHeader: str
 
     @file_exists_check
     def load(self, path):
@@ -32,7 +33,8 @@ class CoNLL(Dataset):
         """
         with open(path, "r") as f:
             for line in f.readlines():
-                if line == "-DOCSTART- -X- O O\n":
+                if str(line).startswith('-DOCSTART-'):
+                    self.datasetFileHeader = str(line)
                     continue
 
                 elif line == "\n":
@@ -121,7 +123,7 @@ class CoNLL(Dataset):
         with open(path, 'w+') as f:
 
             lines = list()
-            lines.append('-DOCSTART- -X- O O\n')
+            lines.append(self.datasetFileHeader)
 
             try:
                 for entry in data:


### PR DESCRIPTION
(Solves #3) To accommodate different CONLL versions, I am using the `startsWith` method. Would be happy to discuss other possible solutions.